### PR TITLE
padding of first convolution set to dilation in residualblock

### DIFF
--- a/models/layers.py
+++ b/models/layers.py
@@ -461,7 +461,7 @@ class ResidualBlock(nn.Module):
     self.normalization = normalization
     if resample == 'down':
       if dilation > 1:
-        self.conv1 = ncsn_conv3x3(input_dim, input_dim, dilation=dilation)
+        self.conv1 = ncsn_conv3x3(input_dim, input_dim, dilation=dilation,padding=dilation)
         self.normalize2 = normalization(input_dim)
         self.conv2 = ncsn_conv3x3(input_dim, output_dim, dilation=dilation)
         conv_shortcut = partial(ncsn_conv3x3, dilation=dilation)


### PR DESCRIPTION
In the case where downsampling is true and dilation>1 there are two convolutions both of which are downsampling by the number of dilation. However the shortcut is only downsampled with one dilation which creates a missmatch between shortcut and output when downsampling is true and dilation>1.

This fix sets the padding=dilation for the first convolution of the ResidualBlock in the case with downsampling 'true' and dilation>1.